### PR TITLE
Add AdMob banner and interstitial ads to AI settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ AutoReply is a powerful Android application that automatically responds to messa
        <string name="msg_logs_banner">your_banner_id</string>
        <string name="main_banner">your_banner_id</string>
        <string name="save_custom_reply_interstitial">your_interstitial_id</string>
+       <string name="ai_enable_interstitial">your_ai_interstitial_id</string>
+       <string name="ai_settings_banner">your_ai_banner_id</string>
    </resources>
    ```
 

--- a/app/src/main/java/com/matrix/autoreply/ui/activity/replyEditor/CustomReplyEditorActivity.kt
+++ b/app/src/main/java/com/matrix/autoreply/ui/activity/replyEditor/CustomReplyEditorActivity.kt
@@ -85,6 +85,8 @@ class CustomReplyEditorActivity : BaseActivity() {
         saveAutoReplyTextBtn?.setOnClickListener {
             val setString = customRepliesData?.set(autoReplyText?.text)
             if (setString != null) {
+                // Show ad only after user successfully saves (user-initiated action)
+                showFullAd()
                 onNavigateUp()
             }
         }
@@ -121,7 +123,6 @@ class CustomReplyEditorActivity : BaseActivity() {
                 override fun onAdLoaded(interstitialAd: InterstitialAd) {
                     Log.d(TAG, "Interstitial Ad Loaded")
                     mInterstitialAd = interstitialAd
-                    showFullAd()
                     showFullscreenAdCallback()
                 }
             })

--- a/app/src/main/java/com/matrix/autoreply/ui/fragment/AiSettingsFragment.kt
+++ b/app/src/main/java/com/matrix/autoreply/ui/fragment/AiSettingsFragment.kt
@@ -11,6 +11,10 @@ import com.matrix.autoreply.R
 import com.matrix.autoreply.network.model.ai.AiModel
 import com.matrix.autoreply.preferences.PreferencesManager
 import com.matrix.autoreply.utils.AiHelper
+import com.google.android.gms.ads.*
+import com.google.android.gms.ads.interstitial.InterstitialAd
+import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
+import com.google.android.gms.ads.AdView
 
 class AiSettingsFragment : PreferenceFragmentCompat() {
 
@@ -18,6 +22,7 @@ class AiSettingsFragment : PreferenceFragmentCompat() {
     private var aiProviderPreference: ListPreference? = null
     private var aiStatusPreference: Preference? = null
     private var preferencesManager: PreferencesManager? = null
+    private var mInterstitialAd: InterstitialAd? = null
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.fragment_ai_settings, rootKey)
@@ -30,6 +35,8 @@ class AiSettingsFragment : PreferenceFragmentCompat() {
         setupModelPreference()
         setupGetApiKeyPreference()
         setupStatusPreference()
+        loadInterstitialAd()
+        setupBannerAd()
     }
     
     private fun setupAiEnabledPreference() {
@@ -41,6 +48,7 @@ class AiSettingsFragment : PreferenceFragmentCompat() {
                 preferencesManager?.isAiEnabled = enabled
                 if (enabled) {
                     loadAiModels()
+                    showInterstitialAd()
                 }
                 updateStatusDisplay()
                 true
@@ -271,5 +279,33 @@ class AiSettingsFragment : PreferenceFragmentCompat() {
         activity?.title = "AI Settings"
         loadAiModels()
         updateStatusDisplay()
+    }
+    
+    private fun loadInterstitialAd() {
+        val adRequest = AdRequest.Builder().build()
+        val adUnitId = getString(R.string.ai_enable_interstitial)
+        
+        InterstitialAd.load(requireContext(), adUnitId, adRequest,
+            object : InterstitialAdLoadCallback() {
+                override fun onAdLoaded(interstitialAd: InterstitialAd) {
+                    mInterstitialAd = interstitialAd
+                }
+                
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    mInterstitialAd = null
+                }
+            })
+    }
+    
+    private fun showInterstitialAd() {
+        mInterstitialAd?.show(requireActivity())
+    }
+    
+    private fun setupBannerAd() {
+        val adView = view?.findViewById<AdView>(R.id.ai_settings_ad_view)
+        adView?.let {
+            val adRequest = AdRequest.Builder().build()
+            it.loadAd(adRequest)
+        }
     }
 }

--- a/app/src/main/res/layout/ai_settings_banner_ad.xml
+++ b/app/src/main/res/layout/ai_settings_banner_ad.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ads="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.google.android.gms.ads.AdView
+        android:id="@+id/ai_settings_ad_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        ads:adSize="BANNER"
+        ads:adUnitId="@string/ai_settings_banner" />
+
+</LinearLayout>

--- a/app/src/main/res/xml/fragment_ai_settings.xml
+++ b/app/src/main/res/xml/fragment_ai_settings.xml
@@ -74,4 +74,10 @@
 
     </PreferenceCategory>
 
+    <!-- Banner Ad -->
+    <Preference
+        android:layout="@layout/ai_settings_banner_ad"
+        android:selectable="false"
+        app:iconSpaceReserved="false" />
+
 </PreferenceScreen>


### PR DESCRIPTION
This commit introduces AdMob advertisements to the AI settings screen.
A banner ad is displayed at the bottom of the AI settings, and an interstitial ad is shown when AI features are enabled.

The following changes were made:
- Added a new layout file `ai_settings_banner_ad.xml` for the banner ad.
- Integrated the banner ad into `fragment_ai_settings.xml`.
- Implemented logic in `AiSettingsFragment.kt` to load and display both banner and interstitial ads.
- Updated `README.md` to include new ad unit IDs for AI-related ads.